### PR TITLE
Refactor recommendation pipeline: deterministic scoring + weighted/name-only toggle

### DIFF
--- a/hooks/use-app-data.tsx
+++ b/hooks/use-app-data.tsx
@@ -4,6 +4,7 @@ import { doc, getDoc } from "firebase/firestore";
 import { authService } from "@/services";
 import type { AuthUser } from "@/services/auth.service";
 import { db } from "@/services/firebase";
+import { normalizeQuestionnaireAnswers } from "@/services/questionnaire.enums";
 
 export type User = {
   uid: string;
@@ -19,7 +20,7 @@ export type User = {
   isProfileComplete?: boolean;
 };
 
-export type QuestionnaireAnswers = Record<string, string>;
+export type QuestionnaireAnswers = Record<string, any>;
 
 export type AppDataState = {
   user: User | null;
@@ -64,7 +65,7 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
         if (!mounted) return;
         if (raw) {
           const parsed = JSON.parse(raw) as AppDataState;
-          setState(parsed);
+          setState({ ...parsed, questionnaireAnswers: normalizeQuestionnaireAnswers(parsed.questionnaireAnswers ?? {}) });
         }
       } catch {
       } finally {
@@ -227,7 +228,8 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setQuestionnaireAnswers = useCallback(async (answers: QuestionnaireAnswers) => {
-    setState((prev) => ({ ...prev, questionnaireAnswers: { ...answers } }));
+    const normalized = normalizeQuestionnaireAnswers(answers);
+    setState((prev) => ({ ...prev, questionnaireAnswers: { ...normalized } }));
   }, []);
 
   const setNotificationsEnabled = useCallback(async (enabled: boolean) => {
@@ -237,7 +239,7 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
   const restoreData = useCallback(async (data: AppDataState) => {
     setState({
       user: data.user ?? null,
-      questionnaireAnswers: data.questionnaireAnswers ?? {},
+      questionnaireAnswers: normalizeQuestionnaireAnswers(data.questionnaireAnswers ?? {}),
       notificationsEnabled: data.notificationsEnabled ?? true,
     });
   }, []);

--- a/services/questionnaire.enums.ts
+++ b/services/questionnaire.enums.ts
@@ -1,0 +1,98 @@
+import type { Language } from './translations';
+import { translations } from './translations';
+
+export const QUESTIONNAIRE_RADIO_OPTIONS = {
+  costOfAttendance: [
+    { key: 'under_20k', labelKey: 'questionnaire.under20k' },
+    { key: '20k_to_40k', labelKey: 'questionnaire.20to40k' },
+    { key: '40k_to_60k', labelKey: 'questionnaire.40to60k' },
+    { key: 'over_60k', labelKey: 'questionnaire.over60k' },
+    { key: 'no_preference', labelKey: 'questionnaire.noPreference' },
+  ],
+  classSize: [
+    { key: 'small', labelKey: 'questionnaire.small' },
+    { key: 'large', labelKey: 'questionnaire.large' },
+    { key: 'no_preference', labelKey: 'questionnaire.noPreference' },
+  ],
+  transportation: [
+    { key: 'car', labelKey: 'questionnaire.transportCar' },
+    { key: 'transit', labelKey: 'questionnaire.transportTransit' },
+    { key: 'bike', labelKey: 'questionnaire.transportBike' },
+    { key: 'walk', labelKey: 'questionnaire.transportWalk' },
+    { key: 'no_preference', labelKey: 'questionnaire.noPreference' },
+  ],
+  inStateOutOfState: [
+    { key: 'in_state', labelKey: 'questionnaire.inState' },
+    { key: 'out_of_state', labelKey: 'questionnaire.outOfState' },
+    { key: 'no_preference', labelKey: 'questionnaire.noPreference' },
+  ],
+  housing: [
+    { key: 'on_campus', labelKey: 'questionnaire.onCampus' },
+    { key: 'off_campus', labelKey: 'questionnaire.offCampus' },
+    { key: 'commute', labelKey: 'questionnaire.commute' },
+    { key: 'no_preference', labelKey: 'questionnaire.noPreference' },
+  ],
+  ranking: [
+    { key: 'very_important', labelKey: 'questionnaire.veryImportant' },
+    { key: 'somewhat_important', labelKey: 'questionnaire.somewhatImportant' },
+    { key: 'not_important', labelKey: 'questionnaire.notImportant' },
+  ],
+  continueEducation: [
+    { key: 'yes', labelKey: 'questionnaire.yes' },
+    { key: 'no', labelKey: 'questionnaire.no' },
+    { key: 'maybe', labelKey: 'questionnaire.maybe' },
+  ],
+} as const;
+
+type RadioField = keyof typeof QUESTIONNAIRE_RADIO_OPTIONS;
+
+type QuestionnaireRecord = Record<string, any>;
+
+const norm = (value: unknown) =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, ' ')
+    .replace(/[^\p{L}\p{N} ]/gu, '');
+
+const allLanguageBundles = Object.values(translations) as Array<Record<string, string>>;
+
+const mapLegacyValue = (field: RadioField, rawValue: unknown, activeLanguage?: Language) => {
+  const v = norm(rawValue);
+  if (!v) return null;
+
+  const options = QUESTIONNAIRE_RADIO_OPTIONS[field];
+  const direct = options.find((opt) => norm(opt.key) === v || norm(opt.key).replace(/ /g, '') === v.replace(/ /g, ''));
+  if (direct) return direct.key;
+
+  const languagesToCheck: Array<Record<string, string>> = [];
+  if (activeLanguage && translations[activeLanguage]) languagesToCheck.push(translations[activeLanguage]);
+  languagesToCheck.push(...allLanguageBundles);
+
+  for (const bundle of languagesToCheck) {
+    for (const option of options) {
+      const translated = bundle[option.labelKey];
+      if (translated && norm(translated) === v) return option.key;
+    }
+  }
+
+  return null;
+};
+
+export function normalizeQuestionnaireAnswers(answers: QuestionnaireRecord | null | undefined, activeLanguage?: Language) {
+  const normalized: QuestionnaireRecord = { ...(answers ?? {}) };
+
+  (Object.keys(QUESTIONNAIRE_RADIO_OPTIONS) as RadioField[]).forEach((field) => {
+    if (!(field in normalized)) return;
+    const mapped = mapLegacyValue(field, normalized[field], activeLanguage);
+    if (mapped) normalized[field] = mapped;
+    else normalized[field] = 'no_preference';
+  });
+
+  if (typeof normalized.useWeightedSearch !== 'boolean') {
+    if (String(normalized.useWeightedSearch).toLowerCase() === 'false') normalized.useWeightedSearch = false;
+    else normalized.useWeightedSearch = true;
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
### Motivation
- Replace the legacy weight system with a deterministic, testable recommendation pipeline that prioritizes realistic admission fit, then prestige, then preference, and finally a small AI factor. 
- Add a simple name-only search mode controlled by `useWeightedSearch` so UI can opt out of the weighted pipeline. 
- Normalize questionnaire radio answers to stable enum keys and migrate legacy translated values to avoid storing translated label strings.

### Description
- Implemented a full deterministic scoring pipeline in `services/ai.service.ts` that computes `gpaFitScore`, `prestigeScore`, `majorFit`, explicit `preferenceFit` (average of `costFit`, `debtFit`, `aidFit`, `sizeFit`, `settingFit`), applies ranking/continue-education adjustments, and composes `finalBaseScore` with the required GPA realism cap. 
- Added a single guarded AI pass (`computeAiFactors`) that is called once on the top 20 deterministic candidates, enforces strict JSON output `{id, aiFactor}`, clamps/parses fallbacks, token-safety rules, and contributes at most 10% to the final score; the final ranking returns top 12 with detailed breakdowns. 
- Added name-only mode to `aiService.recommendColleges(options)` via `useWeightedSearch: boolean` (default `true`), which returns raw `collegeService.searchColleges()` results for queries >= 2 chars and skips all scoring, AI calls, and in‑state filtering as specified. 
- Introduced `services/questionnaire.enums.ts` to define stable enum keys and a `normalizeQuestionnaireAnswers` migration that maps legacy translated strings to enums (best-effort across locales) and enforces `useWeightedSearch` boolean; wired normalization on load/save (`hooks/use-app-data.tsx`) and updated questionnaire/profile UI to render/store enum keys. 

### Testing
- Type-check: `npx tsc --noEmit` completed successfully. 
- Lint: `npm run -s lint` ran and completed (warnings noted but no new errors). 
- Runtime/web start: attempted `npm run web` (Expo) but startup failed in this environment due to upstream `fetch` network errors unrelated to the code changes, so end-to-end web smoke run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953bf32490832c989abc9a45d9c4ee)